### PR TITLE
Add test to see if DOM has changed

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,7 @@ name: run deno script
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 7 * * 4" # Every thursday at 7:00 am UTC
+    - cron: '0 7 * * 4' # Every thursday at 7:00 am UTC
 
 jobs:
   build:
@@ -22,8 +22,11 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Run tests
+        run: deno test --allow-net=kinotickets.express
+
       - name: Build excecutable
-        run: "deno compile --allow-read --allow-write --allow-net main.ts --output cinemacorn"
+        run: 'deno compile --allow-read --allow-write --allow-net main.ts --output cinemacorn'
 
       - name: execute deno
         run: ./cinemacorn

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Find the nicely formatted list
 ### Run project
 
 ```sh
-deno run --allow-read --allow-write --allow-net main.ts
+deno run --allow-read --allow-write --allow-net=kinotickets.express main.ts
 ```
 
 ### Build executable binary
 
 ```sh
-deno compile --allow-read --allow-write --allow-net main.ts --output cinemacorn
+deno compile --allow-read --allow-write --allow-net=kinotickets.express main.ts --output cinemacorn
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ Find the nicely formatted list
 
 - [Deno](https://docs.deno.com/runtime/manual/getting_started/installation/)
 
+### Test project
+
+The project currently contains a simple test to check if any movie is returned
+for both cinemas listed. If nothing is returned this might indicate that the DOM
+has changed again and the selection of HTML tags containing movies needs to be
+adjusted.
+
+You can run the tests by running
+
+```sh
+deno test --allow-net=kinotickets.express
+```
+
 ### Run project
 
 ```sh

--- a/deno.lock
+++ b/deno.lock
@@ -1,26 +1,89 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
     "jsr:@b-fuze/deno-dom@*": "0.1.49",
+    "jsr:@b-fuze/deno-dom@~0.1.49": "0.1.49",
+    "jsr:@denosaurs/plug@1.0.3": "1.0.3",
     "jsr:@std/assert@*": "0.226.0",
+    "jsr:@std/assert@^1.0.10": "1.0.13",
+    "jsr:@std/assert@^1.0.13": "1.0.13",
+    "jsr:@std/assert@~0.213.1": "0.213.1",
     "jsr:@std/datetime@~0.225.3": "0.225.3",
-    "jsr:@std/internal@1": "1.0.1"
+    "jsr:@std/encoding@0.213.1": "0.213.1",
+    "jsr:@std/expect@*": "1.0.16",
+    "jsr:@std/fmt@0.213.1": "0.213.1",
+    "jsr:@std/fs@0.213.1": "0.213.1",
+    "jsr:@std/internal@1": "1.0.1",
+    "jsr:@std/internal@^1.0.6": "1.0.8",
+    "jsr:@std/internal@^1.0.7": "1.0.8",
+    "jsr:@std/path@0.213.1": "0.213.1",
+    "jsr:@std/path@~0.213.1": "0.213.1"
   },
   "jsr": {
     "@b-fuze/deno-dom@0.1.49": {
-      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9"
+      "integrity": "45c40175fdd1e74ab2d4b54c4fdaabbad6e5b76ee28df12a48e076b3fa7901a9",
+      "dependencies": [
+        "jsr:@denosaurs/plug"
+      ]
+    },
+    "@denosaurs/plug@1.0.3": {
+      "integrity": "b010544e386bea0ff3a1d05e0c88f704ea28cbd4d753439c2f1ee021a85d4640",
+      "dependencies": [
+        "jsr:@std/encoding",
+        "jsr:@std/fmt",
+        "jsr:@std/fs",
+        "jsr:@std/path@0.213.1"
+      ]
+    },
+    "@std/assert@0.213.1": {
+      "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
     },
     "@std/assert@0.226.0": {
       "integrity": "0dfb5f7c7723c18cec118e080fec76ce15b4c31154b15ad2bd74822603ef75b3",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@1"
+      ]
+    },
+    "@std/assert@1.0.13": {
+      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.6"
       ]
     },
     "@std/datetime@0.225.3": {
       "integrity": "fda0b7791b43d9a46764986fec39922a8ceb70ffca642651fa7d0683501a171a"
     },
+    "@std/encoding@0.213.1": {
+      "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
+    },
+    "@std/expect@1.0.16": {
+      "integrity": "ceeef6dda21f256a5f0f083fcc0eaca175428b523359a9b1d9b3a1df11cc7391",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/internal@^1.0.7"
+      ]
+    },
+    "@std/fmt@0.213.1": {
+      "integrity": "a06d31777566d874b9c856c10244ac3e6b660bdec4c82506cd46be052a1082c3"
+    },
+    "@std/fs@0.213.1": {
+      "integrity": "fbcaf099f8a85c27ab0712b666262cda8fe6d02e9937bf9313ecaea39a22c501",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1",
+        "jsr:@std/path@~0.213.1"
+      ]
+    },
     "@std/internal@1.0.1": {
       "integrity": "6f8c7544d06a11dd256c8d6ba54b11ed870aac6c5aeafff499892662c57673e6"
+    },
+    "@std/internal@1.0.8": {
+      "integrity": "fc66e846d8d38a47cffd274d80d2ca3f0de71040f855783724bb6b87f60891f5"
+    },
+    "@std/path@0.213.1": {
+      "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
+      "dependencies": [
+        "jsr:@std/assert@~0.213.1"
+      ]
     }
   },
   "redirects": {

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,5 +1,0 @@
-import { assertEquals } from 'jsr:@std/assert';
-
-Deno.test(function addTest() {
-	assertEquals(1, 1);
-});

--- a/tests/dom_changed_test.ts
+++ b/tests/dom_changed_test.ts
@@ -1,0 +1,31 @@
+import { GLOBALS } from '../main.ts';
+import { Cinema } from '../models/cinema.ts';
+import CinemaParser from '../utils/cinema_parser.ts';
+import { HtmlParser } from '../utils/html_parser.ts';
+import WebLoader from '../utils/web_loader.ts';
+import { expect } from 'jsr:@std/expect';
+
+Deno.test({
+	name: 'Check if DOM is unchanged',
+	async fn() {
+		const cinemaPromises = GLOBALS.subPaths.map(
+			async (subPath: string) => {
+				const url = GLOBALS.baseUrl + subPath;
+				const rawDocument = await WebLoader.load(url);
+				const document = HtmlParser.getDocument(rawDocument);
+				return CinemaParser.parseCinema(document, url);
+			},
+		);
+
+		await Promise.all(cinemaPromises).then(
+			(cinemas: Cinema[]) => {
+				expect(cinemas.length).toBe(2);
+				cinemas.forEach((cinema) => {
+					expect(cinema.movies.length).toBeGreaterThanOrEqual(1);
+				});
+			},
+		);
+	},
+	sanitizeResources: false,
+	sanitizeOps: false,
+});

--- a/tests/dom_changed_test.ts
+++ b/tests/dom_changed_test.ts
@@ -34,9 +34,29 @@ Deno.test({
 				expect(testData.length).toBe(GLOBALS.subPaths.length);
 
 				testData.forEach((data) => {
-					// Verify the movieList <ul> was found and contains any amount of movies
+					// Verify the movieList <ul> was found
 					expect(data.movieList).not.toBe(null);
-					expect(data.movieList?.children.length).toBeGreaterThan(0);
+
+					// Verify at least one movie is in the list
+					const movies = data.movieList!.children;
+					expect(movies.length).toBeGreaterThan(0);
+
+					for (let index = 0; index < movies.length; index++) {
+						// Check if every movies schedule, title and poster url can be accessed
+						const movie = movies.item(index);
+
+						const schedule = movie.querySelector('ul')?.getElementsByTagName(
+							'li',
+						);
+						expect(schedule).not.toBe(null);
+
+						const title = movie.querySelector('div > div');
+						expect(title).not.toBe(null);
+
+						const posterUrl =
+							movie.getElementsByTagName('img')[0]?.getAttribute('src') ?? '';
+						expect(posterUrl).not.toBe(null);
+					}
 				});
 			},
 		);

--- a/tests/dom_changed_test.ts
+++ b/tests/dom_changed_test.ts
@@ -4,6 +4,12 @@ import CinemaParser from '../utils/cinema_parser.ts';
 import { HtmlParser } from '../utils/html_parser.ts';
 import WebLoader from '../utils/web_loader.ts';
 import { expect } from 'jsr:@std/expect';
+import { Element } from 'jsr:@b-fuze/deno-dom';
+
+interface CinemaMovieTestData {
+	cinema: Cinema;
+	movieList: Element | null;
+}
 
 Deno.test({
 	name: 'Check if DOM is unchanged',
@@ -13,15 +19,24 @@ Deno.test({
 				const url = GLOBALS.baseUrl + subPath;
 				const rawDocument = await WebLoader.load(url);
 				const document = HtmlParser.getDocument(rawDocument);
-				return CinemaParser.parseCinema(document, url);
+				return {
+					cinema: CinemaParser.parseCinema(document, url),
+					movieList: document.querySelector(
+						'body > main > div > div > div > ul',
+					),
+				} satisfies CinemaMovieTestData;
 			},
 		);
 
 		await Promise.all(cinemaPromises).then(
-			(cinemas: Cinema[]) => {
-				expect(cinemas.length).toBe(2);
-				cinemas.forEach((cinema) => {
-					expect(cinema.movies.length).toBeGreaterThanOrEqual(1);
+			(testData: CinemaMovieTestData[]) => {
+				// Verify we receive always GLOBALS.subPaths.length cinemas
+				expect(testData.length).toBe(GLOBALS.subPaths.length);
+
+				testData.forEach((data) => {
+					// Verify the movieList <ul> was found and contains any amount of movies
+					expect(data.movieList).not.toBe(null);
+					expect(data.movieList?.children.length).toBeGreaterThan(0);
 				});
 			},
 		);

--- a/utils/cinema_parser.ts
+++ b/utils/cinema_parser.ts
@@ -17,6 +17,7 @@ export default class CinemaParser {
 		)?.children;
 		const movieList: Element[] = [];
 		if (!movieListCollection) {
+			console.error('Movie list is empty, check if HTML has changed');
 			return [];
 		}
 		for (let index = 0; index < movieListCollection.length; index++) {


### PR DESCRIPTION
Due to recent events it might make sense to test if the DOM has changed by checking if there's at least one movie per cinema being returned by the script from `main.ts`

The test step is added to the GitHub actions to get notified about missing movies on a scheduled release.